### PR TITLE
runme: Use --keep-cr when applying edk2-platforms patches

### DIFF
--- a/runme.sh
+++ b/runme.sh
@@ -115,7 +115,7 @@ for i in $QORIQ_COMPONENTS; do
 			cd edk2-platforms
 			git checkout -b $RELEASE refs/tags/$RELEASE
 			patch -p1 < $ROOTDIR/patches/edk2-platforms/*.diff
-			git am $ROOTDIR/patches/edk2-platforms/*.patch
+			git am --keep-cr $ROOTDIR/patches/edk2-platforms/*.patch
 		fi
 		if [[ -d $ROOTDIR/patches/$i/ ]]; then
 			git am $ROOTDIR/patches/$i/*.patch


### PR DESCRIPTION
Currently the container build doesn't work because git in the container
needs configuration to correctly handle the CR line endings in
0003-lx2160a-fix-Pcie-bar-allocation.patch. Fix this.