### PR TITLE
Fix UEFI container builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,15 @@ Selecting boot loader - *BOOT_LOADER=u-boot,uefi*
 
 
 ### Examples:
-generate *images/lx2160acex7_2000_700_3200_8_5_2_sd.img*:
+generate *images/lx2160acex7_u-boot_2000_700_3200_8_5_2_sd.img*:
 - `./runme.sh` **or**
 - `docker run --cap-add SYS_ADMIN --device /dev/loop0 --device /dev/loop-control -i -t -v "$PWD":/work lx2160a_build $(id -u) $(id -g)`
 
-generate *images/lx2160acex7_2000_700_3200_8_5_2_xspi.img*:
+generate *images/lx2160acex7_u-boot_2000_700_3200_8_5_2_xspi.img*:
 - `BOOT=xspi ./runme` **or**
 - `docker run --cap-add SYS_ADMIN --device /dev/loop0 --device /dev/loop-control -i -t -v "$PWD":/work -e BOOT=xspi lx2160a_build $(id -u) $(id -g)`
 
 ## Deploying
 For SD card bootable images, plug in a micro SD into your machine and run the following, where sdX is the location of the SD card got probed into your machine -
 
-`sudo dd if=images/lx2160acex7_2000_700_3200_8_5_2_sd.img of=/dev/sdX`
+`sudo dd if=images/lx2160acex7_u-boot_2000_700_3200_8_5_2_sd.img of=/dev/sdX`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get -y install wget make tar p7zip-full squashfs-tools vim \
 	e2fsprogs parted dosfstools acpica-tools mtools \
 	device-tree-compiler xz-utils sudo gcc libssl-dev python2 \
 	bison flex u-boot-tools git bc fuseext2 e2tools multistrap \
-	qemu-user-static g++ cpio python unzip rsync
+	qemu-user-static g++ cpio python unzip rsync uuid-dev
 
 # build environment
 WORKDIR /work

--- a/patches/uefi/0001-BaseTools-header.makefile-add-Wno-stringop-truncatio.patch
+++ b/patches/uefi/0001-BaseTools-header.makefile-add-Wno-stringop-truncatio.patch
@@ -1,0 +1,73 @@
+From 7de6cbe87e175882e4ddaf38a336083bb1dc38e3 Mon Sep 17 00:00:00 2001
+From: Laszlo Ersek <lersek@redhat.com>
+Date: Fri, 2 Mar 2018 17:11:52 +0100
+Subject: [PATCH] BaseTools/header.makefile: add "-Wno-stringop-truncation"
+
+gcc-8 (which is part of Fedora 28) enables the new warning
+"-Wstringop-truncation" in "-Wall". This warning is documented in detail
+at <https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html>; the
+introduction says
+
+> Warn for calls to bounded string manipulation functions such as strncat,
+> strncpy, and stpncpy that may either truncate the copied string or leave
+> the destination unchanged.
+
+It breaks the BaseTools build with:
+
+> EfiUtilityMsgs.c: In function 'PrintMessage':
+> EfiUtilityMsgs.c:484:9: error: 'strncat' output may be truncated copying
+> between 0 and 511 bytes from a string of length 511
+> [-Werror=stringop-truncation]
+>          strncat (Line, Line2, MAX_LINE_LEN - strlen (Line) - 1);
+>          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+> EfiUtilityMsgs.c:469:9: error: 'strncat' output may be truncated copying
+> between 0 and 511 bytes from a string of length 511
+> [-Werror=stringop-truncation]
+>          strncat (Line, Line2, MAX_LINE_LEN - strlen (Line) - 1);
+>          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+> EfiUtilityMsgs.c:511:5: error: 'strncat' output may be truncated copying
+> between 0 and 511 bytes from a string of length 511
+> [-Werror=stringop-truncation]
+>      strncat (Line, Line2, MAX_LINE_LEN - strlen (Line) - 1);
+>      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The right way to fix the warning would be to implement string concat with
+snprintf(). However, Microsoft does not appear to support snprintf()
+before VS2015
+<https://stackoverflow.com/questions/2915672/snprintf-and-visual-studio-2010>,
+so we just have to shut up the warning. The strncat() calls flagged above
+are valid BTW.
+
+Cc: Ard Biesheuvel <ard.biesheuvel@linaro.org>
+Cc: Cole Robinson <crobinso@redhat.com>
+Cc: Liming Gao <liming.gao@intel.com>
+Cc: Paolo Bonzini <pbonzini@redhat.com>
+Cc: Yonghong Zhu <yonghong.zhu@intel.com>
+Contributed-under: TianoCore Contribution Agreement 1.1
+Signed-off-by: Laszlo Ersek <lersek@redhat.com>
+Reviewed-by: Liming Gao <liming.gao@intel.com>
+(cherry picked from commit 1d212a83df0eaf32a6f5d4159beb2d77832e0231)
+Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>
+---
+ BaseTools/Source/C/Makefiles/header.makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/BaseTools/Source/C/Makefiles/header.makefile b/BaseTools/Source/C/Makefiles/header.makefile
+index 27aa28b2fa02..e21f9490cb70 100644
+--- a/BaseTools/Source/C/Makefiles/header.makefile
++++ b/BaseTools/Source/C/Makefiles/header.makefile
+@@ -47,9 +47,9 @@ INCLUDE = $(TOOL_INCLUDE) -I $(MAKEROOT) -I $(MAKEROOT)/Include/Common -I $(MAKE
+ BUILD_CPPFLAGS = $(INCLUDE) -O2
+ ifeq ($(DARWIN),Darwin)
+ # assume clang or clang compatible flags on OS X
+-BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-self-assign -Wno-unused-result -nostdlib -c -g
++BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-stringop-truncation -Wno-self-assign -Wno-unused-result -nostdlib -c -g
+ else
+-BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-unused-result -nostdlib -c -g
++BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-stringop-truncation -Wno-unused-result -nostdlib -c -g
+ endif
+ BUILD_LFLAGS =
+ BUILD_CXXFLAGS = -Wno-unused-result
+-- 
+2.21.0
+

--- a/patches/uefi/0002-BaseTools-header.makefile-add-Wno-restrict.patch
+++ b/patches/uefi/0002-BaseTools-header.makefile-add-Wno-restrict.patch
@@ -1,0 +1,105 @@
+From 7e3225942d1ce826661e5a0069f9bdcc0828f068 Mon Sep 17 00:00:00 2001
+From: Laszlo Ersek <lersek@redhat.com>
+Date: Fri, 2 Mar 2018 17:11:52 +0100
+Subject: [PATCH 2/3] BaseTools/header.makefile: add "-Wno-restrict"
+
+gcc-8 (which is part of Fedora 28) enables the new warning
+"-Wrestrict" in "-Wall". This warning is documented in detail
+at <https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html>; the
+introduction says
+
+> Warn when an object referenced by a restrict-qualified parameter (or, in
+> C++, a __restrict-qualified parameter) is aliased by another argument,
+> or when copies between such objects overlap.
+
+It breaks the BaseTools build (in the Brotli compression library) with:
+
+> In function 'ProcessCommandsInternal',
+>     inlined from 'ProcessCommands' at dec/decode.c:1828:10:
+> dec/decode.c:1781:9: error: 'memcpy' accessing between 17 and 2147483631
+> bytes at offsets 16 and 16 overlaps between 17 and 2147483631 bytes at
+> offset 16 [-Werror=restrict]
+>          memcpy(copy_dst + 16, copy_src + 16, (size_t)(i - 16));
+>          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+> In function 'ProcessCommandsInternal',
+>     inlined from 'SafeProcessCommands' at dec/decode.c:1833:10:
+> dec/decode.c:1781:9: error: 'memcpy' accessing between 17 and 2147483631
+> bytes at offsets 16 and 16 overlaps between 17 and 2147483631 bytes at
+> offset 16 [-Werror=restrict]
+>          memcpy(copy_dst + 16, copy_src + 16, (size_t)(i - 16));
+>          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Paolo Bonzini <pbonzini@redhat.com> analyzed the Brotli source in detail,
+and concluded that the warning is a false positive:
+
+> This seems safe to me, because it's preceded by:
+>
+>     uint8_t* copy_dst = &s->ringbuffer[pos];
+>     uint8_t* copy_src = &s->ringbuffer[src_start];
+>     int dst_end = pos + i;
+>     int src_end = src_start + i;
+>     if (src_end > pos && dst_end > src_start) {
+>       /* Regions intersect. */
+>       goto CommandPostWrapCopy;
+>     }
+>
+> If [src_start, src_start + i) and [pos, pos + i) don't intersect, then
+> neither do [src_start + 16, src_start + i) and [pos + 16, pos + i).
+>
+> The if seems okay:
+>
+>        (src_start + i > pos && pos + i > src_start)
+>
+> which can be rewritten to:
+>
+>        (pos < src_start + i && src_start < pos + i)
+>
+> Then the numbers are in one of these two orders:
+>
+>      pos <= src_start < pos + i <= src_start + i
+>      src_start <= pos < src_start + i <= pos + i
+>
+> These two would be allowed by the "if", but they can only happen if pos
+> == src_start so they degenerate to the same two orders above:
+>
+>      pos <= src_start < src_start + i <= pos + i
+>      src_start <= pos < pos + i <= src_start + i
+>
+> So it is a false positive in GCC.
+
+Disable the warning for now.
+
+Cc: Ard Biesheuvel <ard.biesheuvel@linaro.org>
+Cc: Cole Robinson <crobinso@redhat.com>
+Cc: Liming Gao <liming.gao@intel.com>
+Cc: Paolo Bonzini <pbonzini@redhat.com>
+Cc: Yonghong Zhu <yonghong.zhu@intel.com>
+Reported-by: Cole Robinson <crobinso@redhat.com>
+Contributed-under: TianoCore Contribution Agreement 1.1
+Signed-off-by: Laszlo Ersek <lersek@redhat.com>
+Reviewed-by: Liming Gao <liming.gao@intel.com>
+(cherry picked from commit 9222154ae7b3eef75ae88cdb56158256227cb929)
+Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>
+---
+ BaseTools/Source/C/Makefiles/header.makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/BaseTools/Source/C/Makefiles/header.makefile b/BaseTools/Source/C/Makefiles/header.makefile
+index e21f9490cb70..373def5ef827 100644
+--- a/BaseTools/Source/C/Makefiles/header.makefile
++++ b/BaseTools/Source/C/Makefiles/header.makefile
+@@ -47,9 +47,9 @@ INCLUDE = $(TOOL_INCLUDE) -I $(MAKEROOT) -I $(MAKEROOT)/Include/Common -I $(MAKE
+ BUILD_CPPFLAGS = $(INCLUDE) -O2
+ ifeq ($(DARWIN),Darwin)
+ # assume clang or clang compatible flags on OS X
+-BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-stringop-truncation -Wno-self-assign -Wno-unused-result -nostdlib -c -g
++BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-stringop-truncation -Wno-restrict -Wno-self-assign -Wno-unused-result -nostdlib -c -g
+ else
+-BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-stringop-truncation -Wno-unused-result -nostdlib -c -g
++BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-stringop-truncation -Wno-restrict -Wno-unused-result -nostdlib -c -g
+ endif
+ BUILD_LFLAGS =
+ BUILD_CXXFLAGS = -Wno-unused-result
+-- 
+2.21.0
+

--- a/patches/uefi/0003-BaseTools-GenVtf-silence-false-stringop-overflow-war.patch
+++ b/patches/uefi/0003-BaseTools-GenVtf-silence-false-stringop-overflow-war.patch
@@ -1,0 +1,66 @@
+From 94e26bfdb04b72027219947dad1546a2b167c6c5 Mon Sep 17 00:00:00 2001
+From: Laszlo Ersek <lersek@redhat.com>
+Date: Fri, 2 Mar 2018 17:11:52 +0100
+Subject: [PATCH 3/3] BaseTools/GenVtf: silence false "stringop-overflow"
+ warning with memcpy()
+
+gcc-8 (which is part of Fedora 28) enables the new warning
+"-Wstringop-overflow" in "-Wall". This warning is documented in detail at
+<https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html>; the
+introduction says
+
+> Warn for calls to string manipulation functions such as memcpy and
+> strcpy that are determined to overflow the destination buffer.
+
+It breaks the BaseTools build with:
+
+> GenVtf.c: In function 'ConvertVersionInfo':
+> GenVtf.c:132:7: error: 'strncpy' specified bound depends on the length
+> of the source argument [-Werror=stringop-overflow=]
+>        strncpy (TemStr + 4 - Length, Str, Length);
+>        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+> GenVtf.c:130:14: note: length computed here
+>      Length = strlen(Str);
+>               ^~~~~~~~~~~
+
+It is a false positive because, while the bound equals the length of the
+source argument, the destination pointer is moved back towards the
+beginning of the destination buffer by the same amount (and this amount is
+range-checked first, so we can't precede the start of the dest buffer).
+
+Replace both strncpy() calls with memcpy().
+
+Cc: Ard Biesheuvel <ard.biesheuvel@linaro.org>
+Cc: Cole Robinson <crobinso@redhat.com>
+Cc: Liming Gao <liming.gao@intel.com>
+Cc: Paolo Bonzini <pbonzini@redhat.com>
+Cc: Yonghong Zhu <yonghong.zhu@intel.com>
+Reported-by: Cole Robinson <crobinso@redhat.com>
+Contributed-under: TianoCore Contribution Agreement 1.1
+Signed-off-by: Laszlo Ersek <lersek@redhat.com>
+Reviewed-by: Liming Gao <liming.gao@intel.com>
+(cherry picked from commit 9de306701312f986c9638cb819d3f1f848d55cab)
+Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>
+---
+ BaseTools/Source/C/GenVtf/GenVtf.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/BaseTools/Source/C/GenVtf/GenVtf.c b/BaseTools/Source/C/GenVtf/GenVtf.c
+index 65ae08eeceb8..fc7ae02203ff 100644
+--- a/BaseTools/Source/C/GenVtf/GenVtf.c
++++ b/BaseTools/Source/C/GenVtf/GenVtf.c
+@@ -129,9 +129,9 @@ Returns:
+   } else {
+     Length = strlen(Str);
+     if (Length < 4) {
+-      strncpy (TemStr + 4 - Length, Str, Length);
++      memcpy (TemStr + 4 - Length, Str, Length);
+     } else {
+-      strncpy (TemStr, Str + Length - 4, 4);
++      memcpy (TemStr, Str + Length - 4, 4);
+     }
+   
+     sscanf (
+-- 
+2.21.0
+

--- a/runme.sh
+++ b/runme.sh
@@ -376,7 +376,7 @@ dd if=$ROOTDIR/images/tmp/ubuntu-core.ext4 of=$ROOTDIR/images/tmp/ubuntu-core.im
 
 echo "Assembling Boot Image"
 cd $ROOTDIR/
-IMG=lx2160acex7_${SPEED}_${SERDES}_${BOOT}.img
+IMG=lx2160acex7_${BOOT_LOADER}_${SPEED}_${SERDES}_${BOOT}.img
 truncate -s 465M $ROOTDIR/images/${IMG}
 #dd if=/dev/zero of=$ROOTDIR/images/${IMG} bs=1M count=1
 parted --script $ROOTDIR/images/${IMG} mklabel msdos mkpart primary 64MiB 464MiB

--- a/runme.sh
+++ b/runme.sh
@@ -118,9 +118,10 @@ for i in $QORIQ_COMPONENTS; do
 			git checkout -b $RELEASE refs/tags/$RELEASE
 			patch -p1 < $ROOTDIR/patches/edk2-platforms/*.diff
 			git am --keep-cr $ROOTDIR/patches/edk2-platforms/*.patch
+			cd ..
 		fi
 		if [[ -d $ROOTDIR/patches/$i/ ]]; then
-			git am $ROOTDIR/patches/$i/*.patch
+			git am --keep-cr $ROOTDIR/patches/$i/*.patch
 		fi
 	fi
 done


### PR DESCRIPTION
These patches are required in order to build edk2 using the docker container provided for the builds (well, strictly speaking the third one isn't, but it does make it easier to test both bootloaders by keeping the images seperate).

Basically we must provide the prerequisite packages in the docker image and provide support for a gcc-8 host compiler (because that is what buster gives us). All changes to the code base are direct backports from upstream EDK2.

Build tested only... but since the changes only affect host tools that should be enough!