### PR TITLE
docker: add missing packages for script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN set -e; \
 	apt-get -y upgrade; \
 	:
 
-RUN apt-get -y install wget make tar p7zip-full squashfs-tools vim e2fsprogs parted dosfstools acpica-tools mtools device-tree-compiler xz-utils sudo gcc libssl-dev python2 bison flex u-boot-tools git bc fuseext2
+RUN apt-get -y install wget make tar p7zip-full squashfs-tools vim e2fsprogs parted dosfstools acpica-tools mtools device-tree-compiler xz-utils sudo gcc libssl-dev python2 bison flex u-boot-tools git bc fuseext2 e2tools multistrap qemu-user-static
 
 # build environment
 WORKDIR /work


### PR DESCRIPTION
runme.sh checks for these and fails, so add them during image creation.

Signed-off-by: Olof Johansson <olof@lixom.net>