### PR TITLE
Add python3 to Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get -y install wget make tar p7zip-full squashfs-tools vim \
 	e2fsprogs parted dosfstools acpica-tools mtools \
 	device-tree-compiler xz-utils sudo gcc libssl-dev python2 \
 	bison flex u-boot-tools git bc fuseext2 e2tools multistrap \
-	qemu-user-static g++ cpio python unzip rsync
+	qemu-user-static g++ cpio python python3 unzip rsync
 
 # build environment
 WORKDIR /work


### PR DESCRIPTION
This patch fixed #27 where building via docker fails due `python3` not available by default.