### PR TITLE
docker: add python3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,9 +7,9 @@ RUN set -e; \
 	apt-get -y upgrade; \
 	:
 
-RUN apt-get -y install wget make tar p7zip-full squashfs-tools vim \
+RUN apt-get update ; apt-get -y install wget make tar p7zip-full squashfs-tools vim \
 	e2fsprogs parted dosfstools acpica-tools mtools \
-	device-tree-compiler xz-utils sudo gcc libssl-dev python2 \
+	device-tree-compiler xz-utils sudo gcc libssl-dev python2 python3 \
 	bison flex u-boot-tools git bc fuseext2 e2tools multistrap \
 	qemu-user-static g++ cpio python unzip rsync
 


### PR DESCRIPTION
Python3 is needed to build now. Also, when doing the second install step,
I get some URL errors so do the apt-get update once more (not sure why
it's needed twice).

Signed-off-by: Olof Johansson <olof@lixom.net>