### PR TITLE
docker: fix multistrap configure stage

### DIFF
--- a/patches/u-boot-LSDK-20.04/0020-lx2160a-add-ramdisk_addr_r-for-distro-boot-support.patch
+++ b/patches/u-boot-LSDK-20.04/0020-lx2160a-add-ramdisk_addr_r-for-distro-boot-support.patch
@@ -1,0 +1,45 @@
+From 75cdf0872954e3a096a00a698c3ec9fbd6e1f9c7 Mon Sep 17 00:00:00 2001
+From: Josua Mayer <josua@solid-run.com>
+Date: Wed, 22 Jul 2020 15:22:48 +0200
+Subject: [PATCH] lx2160a: add ramdisk_addr_r for distro-boot support
+
+Because ramdisks can be huge, the addresses were reordered by size so
+that ramdisk is loaded beyond kernel and fdt:
+- 0x81000000: 1MB for DTB
+- 0x81100000: 255MB for Kernel
+- 0x90000000: open end for ramdisk
+
+Signed-off-by: Josua Mayer <josua@solid-run.com>
+---
+ include/configs/lx2160a_common.h | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/include/configs/lx2160a_common.h b/include/configs/lx2160a_common.h
+index d65e5c5cf2..4f23d9a96b 100644
+--- a/include/configs/lx2160a_common.h
++++ b/include/configs/lx2160a_common.h
+@@ -237,7 +237,8 @@ int select_i2c_ch_pca9547_sec(unsigned char ch);
+ 
+ #define EXTRA_ENV_SETTINGS			\
+ 	"hwconfig=fsl_ddr:bank_intlv=auto\0"	\
+-	"ramdisk_addr=0x800000\0"		\
++	"ramdisk_addr=0x90000000\0"		\
++	"ramdisk_addr_r=0x90000000\0"		\
+ 	"ramdisk_size=0x2000000\0"		\
+ 	"fdt_high=0xa0000000\0"			\
+ 	"initrd_high=0xffffffffffffffff\0"	\
+@@ -248,9 +249,9 @@ int select_i2c_ch_pca9547_sec(unsigned char ch);
+ 	"scripthdraddr=0x80080000\0"		\
+ 	"fdtheader_addr_r=0x80100000\0"		\
+ 	"kernelheader_addr_r=0x80200000\0"	\
+-	"kernel_addr_r=0x81000000\0"		\
++	"kernel_addr_r=0x81100000\0"		\
+ 	"kernelheader_size=0x40000\0"		\
+-	"fdt_addr_r=0x90000000\0"		\
++	"fdt_addr_r=0x81000000\0"		\
+ 	"load_addr=0xa0000000\0"		\
+ 	"kernel_size=0x2800000\0"		\
+ 	"kernel_addr_sd=0x8000\0"		\
+-- 
+2.27.0
+

--- a/patches/u-boot-LSDK-20.04/0022-lx2160acex7-drop-ramdisk-from-default-bootargs.patch
+++ b/patches/u-boot-LSDK-20.04/0022-lx2160acex7-drop-ramdisk-from-default-bootargs.patch
@@ -1,0 +1,30 @@
+From b145ea98fe987b7955d11e7f2352b657ed14498f Mon Sep 17 00:00:00 2001
+From: Josua Mayer <josua@solid-run.com>
+Date: Wed, 22 Jul 2020 15:35:30 +0200
+Subject: [PATCH] lx2160acex7: drop ramdisk from default bootargs
+
+root=/dev/ram0 along with ramdisk_size are deployment-specific and
+actually prevent booting a generic distro-boot enabled system that only
+extends rather than override firmware-defined bootargs.
+
+Signed-off-by: Josua Mayer <josua@solid-run.com>
+---
+ configs/lx2160acex7_tfa_defconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configs/lx2160acex7_tfa_defconfig b/configs/lx2160acex7_tfa_defconfig
+index 837d6070dd..97d3877047 100644
+--- a/configs/lx2160acex7_tfa_defconfig
++++ b/configs/lx2160acex7_tfa_defconfig
+@@ -13,7 +13,7 @@ CONFIG_OF_BOARD_SETUP=y
+ CONFIG_OF_STDOUT_VIA_ALIAS=y
+ CONFIG_BOOTDELAY=10
+ CONFIG_USE_BOOTARGS=y
+-CONFIG_BOOTARGS="console=ttyAMA0,115200 root=/dev/ram0 earlycon=pl011,mmio32,0x21c0000 ramdisk_size=0x2000000 default_hugepagesz=1024m hugepagesz=1024m hugepages=2 pci=pcie_bus_perf"
++CONFIG_BOOTARGS="console=ttyAMA0,115200 earlycon=pl011,mmio32,0x21c0000 default_hugepagesz=1024m hugepagesz=1024m hugepages=2 pci=pcie_bus_perf"
+ # CONFIG_USE_BOOTCOMMAND is not set
+ CONFIG_CMD_GREPENV=y
+ CONFIG_CMD_EEPROM=y
+-- 
+2.27.0
+


### PR DESCRIPTION
Rather than qemu user-mode emulation, start a full VM instance for
post-installation.

Signed-off-by: Josua Mayer <josua@solid-run.com>